### PR TITLE
Improve combat UI with better visual feedback and post-combat summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Terminal Dungeon Crawler
+# Terminal Catacomb Crawler
 
-A classic roguelike dungeon crawler game built for the terminal using Python and the `blessed` library.
+A classic roguelike catacomb/dungeons crawler game built for the terminal using Python and the `blessed` library.
 
 ## Table of Contents
 
@@ -136,7 +136,7 @@ black game/ main.py
 
 ## Roadmap
 
-- [ ] **Combat System** - Enemies and turn-based combat
+- [X] **Combat System** - Enemies and turn-based combat
 - [ ] **Items & Equipment** - Weapons, armor, and consumables
 - [ ] **Multiple Levels** - Procedural dungeon generation
 - [ ] **Save/Load** - Game state persistence

--- a/game/engine.py
+++ b/game/engine.py
@@ -23,6 +23,15 @@ class GameEngine:
         self.combat_manager = CombatManager()
         self.combat_messages = []
         
+        # Combat tracking
+        self.combat_stats = {
+            "starting_hp": 0,
+            "starting_level": 0,
+            "starting_exp": 0,
+            "exp_gained": 0,
+            "enemies_defeated": 0
+        }
+        
     def initialize(self):
         """Initialize game components"""
         # Create game objects
@@ -119,6 +128,7 @@ class GameEngine:
         if enemy:
             # Start combat!
             nearby_enemies = self.get_nearby_enemies(self.player.x, self.player.y, radius=1)
+            self.start_combat_tracking()
             combat_start_msg = self.combat_manager.start_combat(self.player, nearby_enemies)
             self.combat_messages.append({"type": "system", "message": combat_start_msg})
             self.needs_render = True
@@ -190,6 +200,11 @@ class GameEngine:
                 turn_msg = self.combat_manager.end_turn()
                 if turn_msg:
                     self.combat_messages.append({"type": "system", "message": turn_msg})
+                    
+                    # Check if combat ended
+                    if not self.combat_manager.in_combat:
+                        self.end_combat_tracking()
+                        
                     self.needs_render = True
             
     def spawn_initial_enemies(self):
@@ -224,6 +239,38 @@ class GameEngine:
         self.terminal.inkey()
         self.running = False
         
+    def start_combat_tracking(self):
+        """Initialize combat statistics tracking"""
+        self.combat_stats = {
+            "starting_hp": self.player.hp,
+            "starting_level": self.player.level,
+            "starting_exp": self.player.exp,
+            "exp_gained": 0,
+            "enemies_defeated": 0
+        }
+        
+    def end_combat_tracking(self):
+        """Finalize combat stats and show summary"""
+        # Calculate final stats
+        health_lost = self.combat_stats["starting_hp"] - self.player.hp
+        self.combat_stats["exp_gained"] = self.player.exp - self.combat_stats["starting_exp"]
+        level_up = self.player.level > self.combat_stats["starting_level"]
+        victory = self.player.hp > 0
+        
+        # Prepare summary data
+        summary = {
+            "victory": victory,
+            "health_lost": health_lost,
+            "exp_gained": self.combat_stats["exp_gained"],
+            "enemies_defeated": self.combat_stats["enemies_defeated"],
+            "level_up": level_up,
+            "new_level": self.player.level if level_up else self.combat_stats["starting_level"]
+        }
+        
+        # Show combat summary screen
+        self.ui.show_combat_summary(summary, self.player)
+        self.needs_render = True
+        
     def player_combat_action(self, action_name):
         """Execute a player combat action"""
         if action_name not in COMBAT_ACTIONS:
@@ -246,10 +293,18 @@ class GameEngine:
         if result["success"]:
             self.combat_messages.append({"type": "combat", **result})
             
+            # Track enemy defeats
+            if result.get("target_died", False):
+                self.combat_stats["enemies_defeated"] += 1
+            
             # End player turn
             turn_msg = self.combat_manager.end_turn()
             if turn_msg:
                 self.combat_messages.append({"type": "system", "message": turn_msg})
+                
+                # Check if combat ended
+                if not self.combat_manager.in_combat:
+                    self.end_combat_tracking()
         else:
             self.combat_messages.append({"type": "system", "message": result.get("message", "Action failed!")})
             
@@ -297,6 +352,7 @@ class GameEngine:
         adjacent_enemies = self.get_nearby_enemies(self.player.x, self.player.y, radius=1)
         if adjacent_enemies:
             # Start combat with adjacent enemies
+            self.start_combat_tracking()
             combat_start_msg = self.combat_manager.start_combat(self.player, adjacent_enemies)
             self.combat_messages.append({"type": "system", "message": combat_start_msg})
             self.needs_render = True

--- a/game/ui.py
+++ b/game/ui.py
@@ -1,7 +1,6 @@
 """
 UI - User interface and display handling
 """
-
 import time
 
 class UI:
@@ -43,23 +42,110 @@ class UI:
         print(self.terminal.bold + "=== COMBAT MODE ===" + self.terminal.normal)
         print()
         
-        # Show combat status
+        # Show player vs enemy health bars side by side
+        self.render_combat_health_comparison(player, enemy_manager)
+        
+        # Show combat status above combat log
         if hasattr(enemy_manager, 'combat_manager') and enemy_manager.combat_manager:
             combat_status = enemy_manager.combat_manager.get_combat_status()
             print(self.terminal.yellow(combat_status))
             print()
-        
-        # Show only health and exp (compact version)
-        self.render_combat_status_bar(player)
-        
-        # Show combat participants
-        self.render_combat_participants(enemy_manager)
         
         # Show combat messages
         self.render_combat_messages(combat_messages)
         
         # Show combat controls
         self.render_controls(in_combat=True, is_player_turn=is_player_turn)
+        
+    def render_combat_health_comparison(self, player, enemy_manager):
+        """Render player vs enemy health bars side by side"""
+        if not hasattr(enemy_manager, 'combat_manager') or not enemy_manager.combat_manager:
+            return
+            
+        # Get current enemy target (first alive enemy in combat)
+        current_enemy = None
+        for participant in enemy_manager.combat_manager.combat_participants:
+            if participant["type"] == "enemy" and participant["entity"].is_alive():
+                current_enemy = participant["entity"]
+                break
+                
+        if not current_enemy:
+            return
+            
+        print("=" * 70)
+        print()
+        
+        # Create the simplified VS layout
+        # Player info
+        player_name = f"⚡ {player.name}"
+        player_hp_percent = player.hp / player.max_hp
+        player_hp_color = self.terminal.green if player_hp_percent > 0.6 else \
+                         self.terminal.yellow if player_hp_percent > 0.3 else \
+                         self.terminal.red
+        player_hp_bar = self.create_bar(player.hp, player.max_hp, 15)
+        player_hp_text = f"{player.hp}/{player.max_hp}"
+        
+        # Enemy info
+        enemy_name = f"👹 {current_enemy.name}"
+        enemy_hp_percent = current_enemy.hp / current_enemy.max_hp
+        enemy_hp_color = self.terminal.green if enemy_hp_percent > 0.6 else \
+                        self.terminal.yellow if enemy_hp_percent > 0.3 else \
+                        self.terminal.red
+        enemy_hp_bar = self.create_bar(current_enemy.hp, current_enemy.max_hp, 15)
+        enemy_hp_text = f"{current_enemy.hp}/{current_enemy.max_hp}"
+        
+        # Format with more spacing
+        player_section = f"{self.terminal.blue(player_name):<25}"
+        enemy_section = f"{self.terminal.red(enemy_name):>25}"
+        print(f"{player_section}        {enemy_section}")
+        
+        # Health bars with VS in the middle
+        player_health = f"{player_hp_color(player_hp_bar)} {player_hp_text}"
+        enemy_health = f"{enemy_hp_color(enemy_hp_bar)} {enemy_hp_text}"
+        vs_text = self.terminal.bold + self.terminal.red(" VS ") + self.terminal.normal
+        
+        # Format health line with proper spacing
+        print(f"{player_health:<35}{vs_text}{enemy_health:>35}")
+        
+        print()
+        print("=" * 70)
+        print()
+        
+    def format_combatant_info(self, combatant, combatant_type):
+        """Format info for a combat participant"""
+        if combatant_type == "player":
+            name = f"{combatant.name}"
+            name_color = self.terminal.blue
+        else:
+            name = f"{combatant.name}"
+            name_color = self.terminal.red
+            
+        # Health info
+        hp_percent = combatant.hp / combatant.max_hp
+        hp_color = self.terminal.green if hp_percent > 0.6 else \
+                   self.terminal.yellow if hp_percent > 0.3 else \
+                   self.terminal.red
+        
+        hp_bar = self.create_bar(combatant.hp, combatant.max_hp, 15)
+        hp_text = f"{combatant.hp}/{combatant.max_hp}"
+        
+        # Additional stats
+        if combatant_type == "player":
+            stats_line = f"ATK:{combatant.attack} DEF:{combatant.defense}"
+            level_line = f"Level {combatant.level}"
+        else:
+            stats_line = f"ATK:{combatant.attack} DEF:{combatant.defense}"
+            level_line = f"Type: {combatant.type.title()}"
+            
+        # Format the info block
+        info_lines = [
+            name_color(name) + self.terminal.normal,
+            hp_color(hp_bar) + self.terminal.normal + f" {hp_text}",
+            stats_line,
+            level_line
+        ]
+        
+        return '\n'.join(info_lines)
         
     def render_map(self, player, level, enemy_manager=None):
         """Render the dungeon map centered on player"""
@@ -120,82 +206,42 @@ class UI:
         
         print("\n" + "=" * 50)
         
-        # Health bar
-        hp_percent = stats['hp'] / stats['max_hp']
-        hp_color = self.terminal.green if hp_percent > 0.6 else \
-                   self.terminal.yellow if hp_percent > 0.3 else \
-                   self.terminal.red
+        # Health bar using helper function
+        health_info = self.create_health_bar_info(player, 20)
+        print(f"Health: {health_info['colored_bar']} ({health_info['text']})")
         
-        hp_bar = self.create_bar(stats['hp'], stats['max_hp'], 20)
-        print(f"Health: {hp_color}{hp_bar}{self.terminal.normal} "
-              f"({stats['hp']}/{stats['max_hp']})")
-        
-        # Experience bar
-        exp_bar = self.create_bar(stats['exp'], stats['exp_to_next'], 20)
-        print(f"EXP:    {self.terminal.blue}{exp_bar}{self.terminal.normal} "
-              f"({stats['exp']}/{stats['exp_to_next']})")
+        # Experience bar using helper function
+        exp_info = self.create_exp_bar_info(player, 20)
+        print(f"EXP:    {exp_info['colored_bar']} ({exp_info['text']})")
         
         # Stats
         print(f"Level: {stats['level']} | "
               f"Attack: {stats['attack']} | "
               f"Defense: {stats['defense']} | "
               f"Position: ({stats['position'][0]}, {stats['position'][1]})")
+
               
     def render_combat_status_bar(self, player):
-        """Render compact player status for combat"""
-        stats = player.get_stats()
-        
+        """Render compact player status for combat (legacy method - now unused)"""
         print("=" * 50)
         
-        # Health bar
-        hp_percent = stats['hp'] / stats['max_hp']
-        hp_color = self.terminal.green if hp_percent > 0.6 else \
-                   self.terminal.yellow if hp_percent > 0.3 else \
-                   self.terminal.red
+        # Health bar using helper function
+        health_info = self.create_health_bar_info(player, 20)
+        print(f"Health: {health_info['colored_bar']} ({health_info['text']})")
         
-        hp_bar = self.create_bar(stats['hp'], stats['max_hp'], 20)
-        print(f"Health: {hp_color}{hp_bar}{self.terminal.normal} "
-              f"({stats['hp']}/{stats['max_hp']})")
-        
-        # Experience bar
-        exp_bar = self.create_bar(stats['exp'], stats['exp_to_next'], 20)
-        print(f"EXP:    {self.terminal.blue}{exp_bar}{self.terminal.normal} "
-              f"({stats['exp']}/{stats['exp_to_next']})")
+        # Experience bar using helper function
+        exp_info = self.create_exp_bar_info(player, 20)
+        print(f"EXP:    {exp_info['colored_bar']} ({exp_info['text']})")
         
         print()
         
-    def render_combat_participants(self, enemy_manager):
-        """Show all participants in combat"""
-        if not hasattr(enemy_manager, 'combat_manager') or not enemy_manager.combat_manager:
-            return
-            
-        print(self.terminal.bold + "Combat Participants:" + self.terminal.normal)
-        
-        for i, participant in enumerate(enemy_manager.combat_manager.combat_participants):
-            entity = participant["entity"]
-            is_current = i == enemy_manager.combat_manager.current_turn_index
-            
-            if participant["type"] == "player":
-                name = f"⚡ {entity.name}"
-                hp_info = f"HP: {entity.hp}/{entity.max_hp}"
-            else:  # enemy
-                name = f"👹 {entity.name}"
-                hp_info = f"HP: {entity.hp}/{entity.max_hp}" if entity.is_alive() else "DEAD"
-                
-            marker = " <-- CURRENT TURN" if is_current else ""
-            color = self.terminal.yellow if is_current else self.terminal.normal
-            
-            print(color + f"  {name} - {hp_info}{marker}" + self.terminal.normal)
-            
-        print()
               
     def render_combat_messages(self, combat_messages):
         """Render recent combat messages"""
         if not combat_messages:
             return
             
-        print("\n" + "-" * 50)
-        print("Combat Log:")
+        print(self.terminal.bold + "Combat Log:" + self.terminal.normal)
         
         # Show last 3 combat messages to avoid clutter
         recent_messages = combat_messages[-3:] if len(combat_messages) > 3 else combat_messages
@@ -206,16 +252,16 @@ class UI:
                     text = f"{msg['attacker']} attacks {msg['target']} for {msg['damage']} damage!"
                     if msg.get("target_died"):
                         text += f" {msg['target']} defeated! (+{msg.get('exp_gained', 0)} XP)"
-                    print(self.terminal.green(text))
+                    print(f"  {self.terminal.green(text)}")
                 elif "defender" in msg:  # Defend action
-                    print(self.terminal.blue(msg["message"]))
+                    print(f"  {self.terminal.blue(msg['message'])}")
                 else:  # Enemy attacking player
                     text = f"{msg['attacker']} attacks you for {msg['damage']} damage!"
                     if msg.get("player_died"):
                         text += " You have fallen!"
-                    print(self.terminal.red(text))
+                    print(f"  {self.terminal.red(text)}")
             elif msg["type"] == "system":
-                print(self.terminal.yellow(msg["message"]))
+                print(f"  {self.terminal.yellow(msg['message'])}")
               
     def create_bar(self, current, maximum, width):
         """Create a text-based progress bar"""
@@ -227,7 +273,7 @@ class UI:
         
     def render_controls(self, in_combat=False, is_player_turn=False):
         """Render control instructions"""
-        print("\n" + "-" * 50)
+        print("-" * 50)
         
         if in_combat:
             if is_player_turn:
@@ -251,6 +297,93 @@ class UI:
         print("\nPress any key to continue...")
         self.terminal.inkey()
         
+    def show_combat_summary(self, combat_stats, player):
+        """Show combat summary screen before returning to exploration"""
+        print(self.terminal.clear)
+        print(self.terminal.bold + "=== COMBAT ENDED ===" + self.terminal.normal)
+        print()
+        
+        # Show victory or defeat
+        if combat_stats.get("victory", False):
+            print(self.terminal.green + self.terminal.bold + "VICTORY!" + self.terminal.normal)
+        else:
+            print(self.terminal.red + self.terminal.bold + "DEFEAT!" + self.terminal.normal)
+        print()
+        
+        print("=" * 50)
+        print("COMBAT SUMMARY")
+        print("=" * 50)
+        
+        # Show health change
+        health_lost = combat_stats.get("health_lost", 0)
+        if health_lost > 0:
+            print(f"Health Lost:    {self.terminal.red}{health_lost}{self.terminal.normal} HP")
+        else:
+            print(f"Health Lost:    {self.terminal.green}0{self.terminal.normal} HP")
+            
+        # Show experience gained
+        exp_gained = combat_stats.get("exp_gained", 0)
+        if exp_gained > 0:
+            print(f"Experience:     {self.terminal.blue}+{exp_gained}{self.terminal.normal} XP")
+        else:
+            print(f"Experience:     {self.terminal.normal}+0{self.terminal.normal} XP")
+            
+        # Show enemies defeated
+        enemies_defeated = combat_stats.get("enemies_defeated", 0)
+        print(f"Enemies Slain:  {enemies_defeated}")
+        
+        print("=" * 50)
+        
+        # Show current player status bars
+        health_info = self.create_health_bar_info(player, 20)
+        print(f"Health: {health_info['colored_bar']} ({health_info['text']})")
+        
+        exp_info = self.create_exp_bar_info(player, 20)
+        print(f"EXP:    {exp_info['colored_bar']} ({exp_info['text']})")
+        
+        # Show level up if applicable
+        if combat_stats.get("level_up", False):
+            print()
+            print(self.terminal.yellow + self.terminal.bold + "LEVEL UP!" + self.terminal.normal)
+            new_level = combat_stats.get("new_level", 1)
+            print(f"You are now level {new_level}!")
+            
+        print()
+        print("=" * 50)
+        print()
+        print("Press any key to return to exploration...")
+        
+        self.terminal.inkey()
+
+    def create_health_bar_info(self, entity, bar_width=15):
+        """Create health bar information for any entity"""
+        hp_percent = entity.hp / entity.max_hp
+        hp_color = self.terminal.green if hp_percent > 0.6 else \
+                   self.terminal.yellow if hp_percent > 0.3 else \
+                   self.terminal.red
+        hp_bar = self.create_bar(entity.hp, entity.max_hp, bar_width)
+        hp_text = f"{entity.hp}/{entity.max_hp}"
+        
+        return {
+            "percent": hp_percent,
+            "color": hp_color,
+            "bar": hp_bar,
+            "text": hp_text,
+            "colored_bar": hp_color(hp_bar) + self.terminal.normal
+        }
+    
+    def create_exp_bar_info(self, player, bar_width=20):
+        """Create experience bar information for player"""
+        exp_bar = self.create_bar(player.exp, player.exp_to_next, bar_width)
+        exp_text = f"{player.exp}/{player.exp_to_next}"
+        colored_bar = self.terminal.blue(exp_bar) + self.terminal.normal
+        
+        return {
+            "bar": exp_bar,
+            "text": exp_text,
+            "colored_bar": colored_bar
+        }    
+
     def show_message(self, message, duration=2):
         """Show a temporary message"""
         # For now, just print it. Later we can add a message log


### PR DESCRIPTION
Combat now displays player and enemy health side-by-side during battles,
making it easier to track the fight's progress. After combat ends, players
see a summary showing health lost, experience gained, and enemies defeated
before returning to exploration.

Also refactored health bar creation code to eliminate duplication across
different UI screens and removed emoji characters for cleaner display.
[In regards to Issue 8](https://github.com/CatacombCrawler/terminal-catacomb-crawler/issues/8)