### PR TITLE
feat: Add custom hero name input during character creation

### DIFF
--- a/game/engine.py
+++ b/game/engine.py
@@ -15,7 +15,7 @@ from .level_up_ui import LevelUpUI
 class GameEngine:
     """Main game engine that handles the core game loop"""
     
-    def __init__(self):
+    def __init__(self, hero_name=None):
         self.terminal = Terminal()
         self.running = False
         self.player = None
@@ -25,6 +25,7 @@ class GameEngine:
         self.combat_manager = CombatManager()
         self.combat_messages = []
         self.character_creator = None
+        self.hero_name = hero_name        
         
         # Door room system
         self.door_rooms = {}  # Dictionary mapping door positions to DoorRoom objects
@@ -50,7 +51,7 @@ class GameEngine:
         self.character_creator = CharacterCreator(self.terminal)
         
         # Create player and run character creation
-        self.player = Player(x=5, y=5)
+        self.player = Player(x=5, y=5, name=self.hero_name or "Hero")
         
         # Run character creation process
         if not self.character_creator.create_character(self.player):

--- a/game/player/player.py
+++ b/game/player/player.py
@@ -9,7 +9,7 @@ from .stats_system import StatsSystem, LEGACY_ALIASES
 class Player:
     """Player character class"""
 
-    def __init__(self, x=0, y=0, archetype='warrior', allocated_main=None):
+    def __init__(self, x=0, y=0, archetype='warrior', allocated_main=None, name="Hero"):
         # Position
         self.x = x
         self.y = y
@@ -60,7 +60,7 @@ class Player:
 
         # Display
         self.symbol = '@'
-        self.name = "Hero"
+        self.name = name
 
         # Inventory and Equipment
         self.inventory = []

--- a/main.py
+++ b/main.py
@@ -17,8 +17,10 @@ def main():
     try:
         print("🏰 Welcome to Terminal Dungeon Crawler! 🏰")
         print("Initializing game...")
+
+        heroName = input("Enter Your Hero's Name: ")
         
-        game = GameEngine()
+        game = GameEngine(hero_name=heroName)
         game.run()
         
     except KeyboardInterrupt:


### PR DESCRIPTION
fixes [#35](https://github.com/CatacombCrawler/terminal-catacomb-crawler/issues/35)

- Add optional 'name' parameter to Player.__init__ with default "Hero"
- Update Player to use the name parameter instead of hardcoded value
- Add hero_name parameter to GameEngine.__init__ and store as instance variable
- Pass hero_name from GameEngine to Player during initialization
- Prompt user for hero name in main.py before game starts
- Thread hero name from main.py -> GameEngine -> Player

This allows players to personalize their character with a custom name that appears throughout the game in combat messages, stats screens, and all UI elements, increasing immersion and player investment.