### PR TITLE
Fix: Ensure legacy base_* stats reflect pre-equipment values (compute derived bases)

### DIFF
--- a/game/player/player.py
+++ b/game/player/player.py
@@ -129,10 +129,11 @@ class Player:
         self.stats.set_equipment_bonuses(bonuses)
 
         # Update legacy properties (compat)
+        # base_* should represent values before equipment; use get_base_stat
         self.base_max_hp = self.stats.get_base_stat('hp')
         self.base_attack = self.stats.get_base_stat('attack')
-        self.base_defense = self.stats.get_stat('defense')
-        self.base_speed = self.stats.get_stat('speed')
+        self.base_defense = self.stats.get_base_stat('defense')
+        self.base_speed = self.stats.get_base_stat('speed')
 
         # Update current stats
         old_max = getattr(self, "max_hp", self.stats.get_stat('hp'))

--- a/game/player/stats_system.py
+++ b/game/player/stats_system.py
@@ -64,9 +64,41 @@ class StatsSystem:
         """
         key = LEGACY_ALIASES.get(name, name)
         self._recalc_if_needed()
+        # If requested stat is a main stat, return main value without equipment
         if key in self._main:
             eq = self.equipment_bonuses.get(key, 0)
             return max(0, self._main[key] - eq)
+
+        # If requested stat is a derived stat, compute derived value based on
+        # mains before equipment (i.e., include class affinities but exclude equipment)
+        if key in self.db.STATS["derived"]:
+            # Build base mains (remove equipment bonuses from mains)
+            base_mains = {}
+            for k in self.db.STATS["main"].keys():
+                base_val = self._main.get(k, 0) - self.equipment_bonuses.get(k, 0)
+                base_mains[k] = base_val
+
+            # Compute derived in topo order using the same logic as _compute_derived
+            derived_def = self.db.STATS["derived"]
+            cls = self.db.CLASSES[self.class_name]
+            d_aff = cls.get("derived_affinity", {})
+
+            order = self._topo_order(list(derived_def.keys()), derived_def)
+            env = dict(base_mains)
+            derived = {}
+            for dkey in order:
+                spec = derived_def[dkey]
+                expr = spec.get("formula", "0")
+                raw_val = self._safe_eval(expr, env)
+                raw_val = max(spec["min_value"], min(spec["max_value"], raw_val))
+                raw_val *= d_aff.get(dkey, 1.0)
+                raw_val = max(spec["min_value"], min(spec["max_value"], raw_val))
+                val = int(round(raw_val)) if raw_val > 20 else round(raw_val, 2)
+                derived[dkey] = val
+                env[dkey] = val
+
+            return derived.get(key, 0)
+
         return 0
 
     def get_all_stats(self):


### PR DESCRIPTION
## Summary
This PR fixes a bug where legacy `base_*` fields (for example `Player.base_max_hp`, `base_attack`, `base_defense`, `base_speed`) could show post-equipment (total) values or be otherwise inconsistent. Legacy fields should represent pre-equipment values (main stats after class starting bonuses/allocations and derived stats computed from those mains). Some game logic and UI relied on that contract.

## What I changed
- **game/player/player.py**
  - Populate legacy fields (`base_max_hp`, `base_attack`, `base_defense`, `base_speed`) using `StatsSystem.get_base_stat(...)` in `__init__` and `recalculate_stats`.
  - Fixed indentation and ensured `recalculate_stats` updates legacy and current stats consistently.
- **game/player/stats_system.py**
  - Enhanced `StatsSystem.get_base_stat(name)`:
    - If `name` is a main stat: returns the main stat value without equipment (existing behavior).
    - If `name` is a derived stat (e.g., `hp` / `health`): compute that derived stat from mains that exclude equipment bonuses. Computation uses the same topo-order and safe evaluator logic as `_compute_derived` so derived dependencies are handled correctly.
- **issue.md**
  - Added reproduction steps and rationale for reviewers.

## Why this fixes the problem
- Previously, `Player` sometimes used `get_stat` or `get_base_stat` did not compute derived stats, so `base_*` could be incorrect or include equipment values.
- Now, legacy `base_*` fields represent true pre-equipment base values. This aligns with expectations across the codebase (level bonuses, UI, diagnostics) and avoids surprising behavior where `base_max_hp` changed when equipping items.

## How I tested
Manual smoke test in the project environment:
```python
from game.player.player import Player
p = Player()
print("max_hp:", p.max_hp, "base_max_hp:", p.base_max_hp)
```
- Observed: `max_hp` and `base_max_hp` matched for a fresh player with no equipment.
- Verified no import/indentation/runtime errors.

## Files changed
- `game/player/player.py`
- `game/player/stats_system.py`
- `issue.md`

## Backwards compatibility & risk
- Backwards compatible: no changes to public method signatures. `get_base_stat` now returns derived base values where appropriate.
- Risk: Low. Changes are isolated to stat computation and legacy-field updates. Computing derived base values on demand uses the same logic as existing derived computations; the StatsSystem dirty/caching behaviour limits repeated cost.

## Suggested follow-ups
- Add unit tests:
  - `StatsSystem.get_base_stat('hp')` returns expected pre-equipment health.
  - `Player.base_max_hp` does not change when equipping items (only `max_hp` changes).
- Update documentation/changelog to note the fix.

closes #46 